### PR TITLE
change(shared-lib): calculate-object-dimensions (#132)

### DIFF
--- a/packages/shared-lib/src/template/calculate-object-dimensions.test.js
+++ b/packages/shared-lib/src/template/calculate-object-dimensions.test.js
@@ -30,7 +30,7 @@ test("calculate-object-dimensions: should calculate dimensions of TextBox", () =
   };
 
   expect(calculateObjectDimensions(object)).toStrictEqual({
-    width: object.width,
+    width: object.width * object.scaleX,
     height: object.height,
   });
 });

--- a/packages/shared-lib/src/template/calculate-object-dimensions.test.js
+++ b/packages/shared-lib/src/template/calculate-object-dimensions.test.js
@@ -31,7 +31,7 @@ test("calculate-object-dimensions: should calculate dimensions of TextBox", () =
 
   expect(calculateObjectDimensions(object)).toStrictEqual({
     width: object.width * object.scaleX,
-    height: object.height,
+    height: object.height * object.scaleY,
   });
 });
 

--- a/packages/shared-lib/src/template/calculate-object-dimensions.ts
+++ b/packages/shared-lib/src/template/calculate-object-dimensions.ts
@@ -18,15 +18,15 @@
  */
 //endregion
 
-import fabric from "fabric/fabric-impl";
+import { TemplateObject } from "@fantastic-images/types/src/TemplateObject";
 
-const getWidth = (object: fabric.Object) =>
+const getWidth = (object: TemplateObject) =>
   (object.width || 0) * (object.scaleX as number);
 
-const getHeight = (object: fabric.Object) =>
+const getHeight = (object: TemplateObject) =>
   (object.height || 0) * (object.scaleY as number);
 
-export const calculateObjectDimensions = (object: fabric.Object) => ({
+export const calculateObjectDimensions = (object: TemplateObject) => ({
   width: getWidth(object),
   height: getHeight(object),
 });

--- a/packages/shared-lib/src/template/calculate-object-dimensions.ts
+++ b/packages/shared-lib/src/template/calculate-object-dimensions.ts
@@ -24,8 +24,7 @@ const getWidth = (object: fabric.Object) =>
   (object.width || 0) * (object.scaleX as number);
 
 const getHeight = (object: fabric.Object) =>
-  (object.height || 0) *
-  (object.type === "image" ? (object.scaleY as number) : 1);
+  (object.height || 0) * (object.scaleY as number);
 
 export const calculateObjectDimensions = (object: fabric.Object) => ({
   width: getWidth(object),

--- a/packages/shared-lib/src/template/calculate-object-dimensions.ts
+++ b/packages/shared-lib/src/template/calculate-object-dimensions.ts
@@ -21,8 +21,7 @@
 import fabric from "fabric/fabric-impl";
 
 const getWidth = (object: fabric.Object) =>
-  (object.width || 0) *
-  (object.type === "image" ? (object.scaleX as number) : 1);
+  (object.width || 0) * (object.scaleX as number);
 
 const getHeight = (object: fabric.Object) =>
   (object.height || 0) *


### PR DESCRIPTION
Closes #132. Now calculate-object-dimensions uses scaleX;scaleY on all objects