### PR TITLE
fix(shared-lib): fixes imports of fantastic-images/lib to named imports

### DIFF
--- a/packages/shared-lib/src/template/update-selected-items.ts
+++ b/packages/shared-lib/src/template/update-selected-items.ts
@@ -18,14 +18,8 @@
  */
 //endregion
 
-import * as lib from "@fantastic-images/lib";
+import { UPDATE_OBJECT } from "@fantastic-images/lib/dist/model/mutations/update-object";
 import { Template, TemplateObject } from "@fantastic-images/types";
-
-const {
-  model: {
-    mutations: { UPDATE_OBJECT },
-  },
-} = lib;
 
 export type fnFunction = ({
   objects,


### PR DESCRIPTION
Veja https://github.com/guesant/fantastic-images/issues/42 e
https://github.com/guesant/fantastic-images/issues/43